### PR TITLE
Fix `manage.py update` causing an incorrect assets build

### DIFF
--- a/server_management/management/commands/update.py
+++ b/server_management/management/commands/update.py
@@ -227,8 +227,8 @@ class Command(BaseCommand):
                         remote['server'].get('settings_file', 'production')
                     )):
 
-                        if '.scss' in git_changes or '.js' in git_changes:
-                            sudo('webpack')
+                        if 'assets/' in git_changes:
+                            run('NODE_ENV=production webpack')
 
                         run('./manage.py collectstatic --noinput')
 


### PR DESCRIPTION
NODE_ENV=production should be in the environment when webpack is run to ensure that assets are built for production, not dev.

Also, rather than looking for any change to `.scss` or '.js', look for any changes in the `assets/` directory. This allows using webpack for image management, and as all assets to be built always live within `assets`, this is better than checking for every possible file extension.
