### PR TITLE
Allow AWS check to be set in server.json with an is_aws flag on remotes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The commands are all wrappers around [Ansible's](/ansible/ansible) [Python API](
 To install ``onespacemedia-server-management`` simply run:
 
     $ pip install onespacemedia-server-management
-    
+
 ## Configuration
 
 We need to add ``onespacemedia-server-management`` to our project, so add ``server_management`` to your ``INSTALLED_APPS``.
@@ -38,7 +38,7 @@ We need to add ``onespacemedia-server-management`` to our project, so add ``serv
         ...
         'server_management',
     ]
-    
+
 Next, you need to create a ``server.json`` file which contains the information about your remote server and your database. This will live in the project folder above ``manage.py``, you can print the exact location with ``settings.SITE_ROOT``. Some example files are below:
 
 ### Single host
@@ -57,7 +57,8 @@ Next, you need to create a ``server.json`` file which contains the information a
                 "name": "example_prod",
                 "user": "example_prod_user",
                 "password": ""
-            }
+            },
+            "is_aws": false,
         }
     }
 
@@ -83,6 +84,7 @@ Please note that the `remote` key changes to `remotes`.
                     "name": "example_prod",
                     "user": "example_prod_user"
                 }
+                "is_aws": false,
             },
             "production": {
                 "server": {
@@ -145,7 +147,6 @@ The deploy script is the most complex command in the library, but saves many man
 	* Installs ``bower`` with ``npm``.
 	* Installs ``gulp`` with ``npm``.
 	* Installs ``virtualenv`` with pip.
-	* 
 * PostgreSQL actions:
 	* Installs PostgreSQL with the following packages:
 	    * ``postgresql-9.3``
@@ -189,7 +190,7 @@ The deploy script is the most complex command in the library, but saves many man
 	* Dumps the local database, uploads it and imports it.
 	* Uploads the local media files to the remote server.
 
-	
+
 ### PullDB
 * Dumps the database on the remote server to an SQL file.
 * Pulls the database file down the the local machine (using ``scp``).

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Please note that the `remote` key changes to `remotes`.
         }
     }
 
+When running one of the management commands, you will be prompted for a remote host on which to perform the operation. To skip this prompt, specify the _name_ of the remote as a positional argument. For example, if you wanted to update the host named as `production` above, you would use `manage.py deploy production`.
 
 The default PostgreSQL deployment uses trust authentication for connecting to the database, so a password is not usually required.
 
@@ -106,7 +107,6 @@ Update your ``STATIC_ROOT`` and ``MEDIA_ROOT`` to match the format the scripts e
 
     STATIC_ROOT = "/var/www/example_static"
     MEDIA_ROOT = "/var/www/example_media"
-
 
 ## Usage
 

--- a/server_management/management/commands/_core.py
+++ b/server_management/management/commands/_core.py
@@ -50,8 +50,15 @@ def load_config(env):
     env.disable_known_hosts = True
     env.reject_unknown_hosts = False
 
-    # Ask the user if the server we are hosting on is AWS
-    aws_check = 'amazonaws.com' in env.host_string or confirm('Is this host on AWS?', default=False)
+    # If is_aws is explicitly declared, trust it.
+    if 'is_aws' in remote:
+        aws_check = remote['is_aws']
+    # Try to guess it from the hostname.
+    elif 'amazonaws.com' in env.host_string:
+        aws_check = True
+    # Dunno, ask the user.
+    else:
+        aws_check = confirm('Is this host on AWS?', default=False)
 
     if aws_check:
         if 'initial_user' in remote['server']:

--- a/server_management/management/commands/backupdb.py
+++ b/server_management/management/commands/backupdb.py
@@ -1,16 +1,15 @@
-from django.core.management.base import BaseCommand
 from django.utils.timezone import now
 
-from _core import load_config
+from _core import load_config, ServerManagementBaseCommand
 
 from fabric.api import *
 
 
-class Command(BaseCommand):
+class Command(ServerManagementBaseCommand):
 
     def handle(self, *args, **options):
         # Load server config from project
-        config, remote = load_config(env)
+        config, remote = load_config(env, options["remote"])
 
         with settings(warn_only=True):
             # Dump the database on the server.

--- a/server_management/management/commands/deploy.py
+++ b/server_management/management/commands/deploy.py
@@ -5,19 +5,18 @@ from urllib import urlencode
 
 from django.conf import settings as django_settings
 from django.core.files.temp import NamedTemporaryFile
-from django.core.management.base import BaseCommand
 from django.template.loader import render_to_string
 from fabric.api import *
 import requests
 
-from _core import load_config, ansible_task, run_tasks, check_request
+from _core import load_config, ansible_task, run_tasks, check_request, ServerManagementBaseCommand
 
 
-class Command(BaseCommand):
+class Command(ServerManagementBaseCommand):
 
     def handle(self, *args, **options):
         # Load server config from project
-        config, remote = load_config(env)
+        config, remote = load_config(env, options["remote"])
 
         # Set local project path
         local_project_path = django_settings.SITE_ROOT

--- a/server_management/management/commands/pulldb.py
+++ b/server_management/management/commands/pulldb.py
@@ -1,15 +1,13 @@
-from django.core.management.base import BaseCommand
-
-from _core import load_config
+from _core import load_config, ServerManagementBaseCommand
 
 from fabric.api import *
 
 
-class Command(BaseCommand):
+class Command(ServerManagementBaseCommand):
 
     def handle(self, *args, **options):
         # Load server config from project
-        config, remote = load_config(env)
+        config, remote = load_config(env, options["remote"])
 
         with settings(warn_only=True):
             # Dump the database on the server.

--- a/server_management/management/commands/pullmedia.py
+++ b/server_management/management/commands/pullmedia.py
@@ -1,16 +1,15 @@
 from django.conf import settings as django_settings
-from django.core.management.base import BaseCommand
 from fabric.api import *
 
-from _core import load_config
+from _core import load_config, ServerManagementBaseCommand
 import os
 
 
-class Command(BaseCommand):
+class Command(ServerManagementBaseCommand):
 
     def handle(self, *args, **options):
         # Load server config from project
-        config, remote = load_config(env)
+        config, remote = load_config(env, options["remote"])
 
         # Set local project path
         local_project_path = django_settings.SITE_ROOT

--- a/server_management/management/commands/pushdb.py
+++ b/server_management/management/commands/pushdb.py
@@ -1,17 +1,15 @@
-from django.core.management.base import BaseCommand
-
-from _core import load_config
+from _core import load_config, ServerManagementBaseCommand
 
 from fabric.api import *
 
 import os
 
 
-class Command(BaseCommand):
+class Command(ServerManagementBaseCommand):
 
     def handle(self, *args, **options):
         # Load server config from project
-        config, remote = load_config(env)
+        config, remote = load_config(env, options["remote"])
 
         with settings(warn_only=True):
 

--- a/server_management/management/commands/pushmedia.py
+++ b/server_management/management/commands/pushmedia.py
@@ -1,20 +1,20 @@
 from django.conf import settings as django_settings
 from django.core.management.base import BaseCommand
 
-from _core import load_config
+from _core import load_config, ServerManagementBaseCommand
 
 from fabric.api import *
 import os
 
 
-class Command(BaseCommand):
+class Command(ServerManagementBaseCommand):
 
     def __init__(self):
         super(Command, self).__init__()
 
     def handle(self, *args, **options):
         # Load server config from project
-        config, remote = load_config(env)
+        config, remote = load_config(env, options["remote"])
 
         # Set local project path
         local_project_path = django_settings.SITE_ROOT

--- a/server_management/management/commands/update.py
+++ b/server_management/management/commands/update.py
@@ -1,9 +1,8 @@
 from django.conf import settings as django_settings
-from django.core.management.base import BaseCommand
 from fabric.api import *
 from fabvenv import virtualenv
 
-from _core import load_config
+from _core import load_config, ServerManagementBaseCommand
 
 import datetime
 import json
@@ -12,7 +11,7 @@ import os
 import sys
 
 
-class Command(BaseCommand):
+class Command(ServerManagementBaseCommand):
 
     endpoint = "https://hooks.slack.com/services/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"
     channel = '#commits'
@@ -165,7 +164,7 @@ class Command(BaseCommand):
         self._notify_start()
 
         # Load server config from project
-        config, remote = load_config(env)
+        config, remote = load_config(env, options["remote"])
 
         # Set local project path
         local_project_path = django_settings.SITE_ROOT


### PR DESCRIPTION
This stops the user from being prompted every time they run a `manage.py update`. Resolves #19 in a different way; having it in the configuration (which means doing it once) is better than having it in argv (which has to be remembered for every update).
