### PR TITLE
Restart memcached on `update`.

### DIFF
--- a/server_management/management/commands/update.py
+++ b/server_management/management/commands/update.py
@@ -250,6 +250,7 @@ class Command(ServerManagementBaseCommand):
                             sudo('./manage.py buildwatson', user=project_folder)
 
                         sudo('supervisorctl restart {}'.format(project_folder))
+                        sudo('service memcached restart')
                         sudo('chown {}:webapps -R /var/www/*'.format(project_folder))
 
         # Register the release with Opbeat.


### PR DESCRIPTION
As we've started to cache more aggressively, it's necessary to flush the cache for pages so that template changes are visible immediately. Restarting memcached is the simplest way of doing this.
