### PR TITLE
Remove memcached from startup runlevels and stop it before adding to supervisor config

### DIFF
--- a/server_management/management/commands/deploy.py
+++ b/server_management/management/commands/deploy.py
@@ -825,6 +825,13 @@ class Command(ServerManagementBaseCommand):
                 }
             },
             {
+                'title': "Stopping memcached and removing from startup runlevels",
+                'ansible_arguments': {
+                    'module_name': 'service',
+                    'module_args': 'name=memcached state=stopped enabled=no'
+                }
+            },
+            {
                 'title': "Create the Supervisor config file for memcached",
                 'ansible_arguments': {
                     'module_name': 'copy',


### PR DESCRIPTION
This fixes #35 - it stops the memcached service and removes it from the standard Ubuntu boot/runlevel process, allowing supervisor to handle it entirely.
