### PR TITLE
Remove Ansible, add HTTP/2 & Let's Encrypt

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Once ``onespacemedia-server-management`` has been added to your project you will
 
 The deploy script is the most complex command in the library, but saves many man-hours upon use.  The steps it takes are as follows:
 
-#### On your machine
+#### On your machine
 * Check if a connection can be made to the remove server using the username ``root`` and the IP specified in the ``server.json``.
 * Parses the username and repo name from the current git remote.
 * Requests a valid Github token or Bitbucket username and password.

--- a/server_management/management/commands/_core.py
+++ b/server_management/management/commands/_core.py
@@ -2,11 +2,11 @@ from optparse import make_option
 
 from django.conf import settings
 from django.core.management.base import BaseCommand
-from fabric.api import hide, prompt, run, settings as fabric_settings
+import fabric
+from fabric.api import hide, prompt, run, settings as fabric_settings, fastprint
 from fabric.contrib.console import confirm
+from fabric.colors import green, yellow, red
 import json
-import ansible.runner
-import ansible.inventory
 import sys
 
 
@@ -18,10 +18,17 @@ class ServerManagementBaseCommand(BaseCommand):
             default=None,
             help='remote host'
         ),
+
+        make_option(
+            '--debug',
+            dest='debug',
+            action='store_true',
+            default=False,
+        ),
     )
 
 
-def load_config(env, remote=None, config_user='deploy'):
+def load_config(env, remote=None, config_user='deploy', debug=False):
     env['sudo_prefix'] += '-H '
 
     # Load the json file
@@ -31,43 +38,32 @@ def load_config(env, remote=None, config_user='deploy'):
         ))
         config = json.load(json_data)
     except:
-        raise Exception(
-            "Something is wrong with the server.json file, make sure it exists and is valid JSON.")
+        raise Exception("Something is wrong with the server.json file, make sure it exists and is valid JSON.")
 
     # Define current host from settings in server config
     # First check if there is a single remote or multiple.
-    if 'remote' in config:
-        env.host_string = config['remote']['server']['ip']
-        remote = config['remote']
-        config['remote_name'] = 'production'
-    elif 'remotes' in config:
-        # Prompt for a host selection.
-        remote_keys = config['remotes'].keys()
-        if len(remote_keys) == 0:
-            print "No remotes specified in config."
-            exit()
-        elif len(remote_keys) == 1:
-            remote_prompt = remote_keys[0]
+    if 'remotes' not in config or not config['remotes']:
+        raise Exception("No remotes specified in config.")
 
-        elif remote:
-            remote_prompt = remote
-            if remote_prompt not in remote_keys:
-                raise Exception("Invalid remote name `{}`.".format(remote))
-                exit()
-        else:
-            print "Available hosts: {}".format(
-                ', '.join(config['remotes'].keys())
-            )
+    # Prompt for a host selection.
+    remote_keys = config['remotes'].keys()
+    if len(remote_keys) == 1:
+        remote_prompt = remote_keys[0]
+    elif remote:
+        if remote_prompt not in remote_keys:
+            raise Exception("Invalid remote name `{}`.".format(remote))
 
-            remote_prompt = prompt("Please enter a remote: ",
-                                   default=remote_keys[0])
-
-        env.host_string = config['remotes'][remote_prompt]['server']['ip']
-        remote = config['remotes'][remote_prompt]
-        config['remote_name'] = remote_prompt
+        remote_prompt = remote
     else:
-        print "No remotes specified in config."
-        exit()
+        print "Available hosts: {}".format(
+            ', '.join(config['remotes'].keys())
+        )
+
+        remote_prompt = prompt("Please enter a remote: ", default=remote_keys[0], validate=lambda x: x in remote_keys)
+
+    remote = config['remotes'][remote_prompt]
+    env.host_string = remote['server']['ip']
+    config['remote_name'] = remote_prompt
 
     env.user = config_user
     env.disable_known_hosts = True
@@ -109,51 +105,48 @@ def load_config(env, remote=None, config_user='deploy'):
                 print "Failed to connect to remote server"
                 exit()
 
+    if not debug:
+        # Change the output to be less verbose.
+        fabric.state.output['stdout'] = False
+        fabric.state.output['running'] = False
+
     # Return the server config
     return config, remote
 
 
-def check_request(request, env, request_type, color='\033[95m'):
-    if len(request['dark']) or request['contacted'][env.host_string].get(
-            'failed', None) is True:
-        print "[{}{}\033[0m] [\033[91mFAILED\033[0m]".format(color,
-                                                             request_type)
-        print request
-        exit()
-    else:
-        print "[{}{}\033[0m] [\033[92mDONE\033[0m]".format(color, request_type)
-
-
-def ansible_task(env, **kwargs):
-    # Create ansible inventory
-    ansible_inventory = ansible.inventory.Inventory([env.host_string])
-
-    ansible_args = dict({
-                            'pattern': 'all',
-                            'inventory': ansible_inventory,
-                            'sudo': True,
-                            'sudo_user': 'root',
-                            'remote_user': env.user
-                        }.items() + kwargs.items())
-
-    if getattr(env, 'key_filename'):
-        ansible_args['private_key_file'] = env.key_filename
-
-    return ansible.runner.Runner(**ansible_args).run()
-
+def check_request(task, result):
+    if result.succeeded:
+        fastprint('\r[{}] {} ... done'.format(
+            green('TASK'),
+            task['title'],
+        ), end='\n')
+    elif result.failed:
+        fastprint('\r[{}] {} ... failed'.format(
+            red('TASK'),
+            task['title'],
+        ), end='\n')
 
 def run_tasks(env, tasks):
     # Loop tasks
     for task in tasks:
+        fastprint('[{}] {} ... '.format(
+            yellow('TASK'),
+            task['title'],
+        ))
+
+        # Generic command
+        if 'command' in task:
+            task_result = run(task['command'])
+        # Fabric API
+        elif 'fabric_command' in task:
+            task_result = getattr(fabric.api, task['fabric_command'])(*task.get('fabric_args', []), **task.get('fabric_kwargs', {}))
 
         if not task.get('with_items'):
-            print "[\033[95mTASK\033[0m] {}...".format(task['title'])
 
             # Run task with arguments
-            task_result = ansible_task(env, **task['ansible_arguments'])
 
             # Check result
-            check_request(task_result, env, "TASK")
+            check_request(task, task_result)
 
         else:
             print "[\033[95mTASK\033[0m] {}...".format(task['title'])
@@ -165,8 +158,7 @@ def run_tasks(env, tasks):
                 print "[\033[94mITEM\033[0m] {}".format(item)
 
                 # Format args with item
-                task['ansible_arguments'][
-                    'module_args'] = module_args_pattern.format(
+                task['ansible_arguments']['module_args'] = module_args_pattern.format(
                     item=item
                 )
 
@@ -177,5 +169,3 @@ def run_tasks(env, tasks):
                 check_request(task_result, env, "ITEM", color='\033[94m')
 
             print "[\033[95mTASK\033[0m] [\033[92mDONE\033[0m]"
-
-        print ""

--- a/server_management/management/commands/_core.py
+++ b/server_management/management/commands/_core.py
@@ -1,13 +1,13 @@
 from optparse import make_option
 
+import json
+import sys
 from django.conf import settings
 from django.core.management.base import BaseCommand
 import fabric
 from fabric.api import hide, prompt, run, settings as fabric_settings, fastprint, sudo
 from fabric.contrib.console import confirm
 from fabric.colors import green, yellow, red
-import json
-import sys
 
 
 class ServerManagementBaseCommand(BaseCommand):
@@ -147,6 +147,7 @@ def check_request(task, result):
     elif result.failed:
         title_print(task['title'], state='failed')
 
+
 def run_tasks(env, tasks, user=None):
     # Loop tasks
     for task in tasks:
@@ -162,31 +163,5 @@ def run_tasks(env, tasks, user=None):
         elif 'fabric_command' in task:
             task_result = getattr(fabric.api, task['fabric_command'])(*task.get('fabric_args', []), **task.get('fabric_kwargs', {}))
 
-        if not task.get('with_items'):
-
-            # Run task with arguments
-
-            # Check result
-            check_request(task, task_result)
-
-        else:
-            print "[\033[95mTASK\033[0m] {}...".format(task['title'])
-
-            # Store task args pattern
-            module_args_pattern = task['ansible_arguments']['module_args']
-
-            for item in task.get('with_items'):
-                print "[\033[94mITEM\033[0m] {}".format(item)
-
-                # Format args with item
-                task['ansible_arguments']['module_args'] = module_args_pattern.format(
-                    item=item
-                )
-
-                # Run task with arguments
-                task_result = ansible_task(env, **task['ansible_arguments'])
-
-                # Check result
-                check_request(task_result, env, "ITEM", color='\033[94m')
-
-            print "[\033[95mTASK\033[0m] [\033[92mDONE\033[0m]"
+        # Check result
+        check_request(task, task_result)

--- a/server_management/management/commands/backupdb.py
+++ b/server_management/management/commands/backupdb.py
@@ -1,8 +1,7 @@
 from django.utils.timezone import now
+from fabric.api import env, local, settings, sudo
 
-from _core import load_config, ServerManagementBaseCommand
-
-from fabric.api import *
+from ._core import load_config, ServerManagementBaseCommand
 
 
 class Command(ServerManagementBaseCommand):

--- a/server_management/management/commands/backupdb.py
+++ b/server_management/management/commands/backupdb.py
@@ -12,7 +12,7 @@ class Command(ServerManagementBaseCommand):
 
         with settings(warn_only=True):
             # Dump the database on the server.
-            sudo("su - {user} -c 'pg_dump {name} -cOx -U {user} -f /home/{user}/{name}.sql --clean'".format(
+            sudo('su - {user} -c \'pg_dump {name} -cOx -U {user} -f /home/{user}/{name}.sql --clean\''.format(
                 name=remote['database']['name'],
                 user=remote['database']['user'],
             ))

--- a/server_management/management/commands/deploy.py
+++ b/server_management/management/commands/deploy.py
@@ -211,7 +211,8 @@ class Command(ServerManagementBaseCommand):
         if 'optional_packages' in config:
             optional_packages = config['optional_packages']
 
-        python_version = remote['server'].get('python_version', '3')
+        python_version_full = remote['server'].get('python_version', '3')
+        python_version = python_version_full[0]
         pip_command = 'pip{}'.format(python_version if python_version == '3' else '')
         python_command = 'python{}'.format(python_version if python_version == '3' else '')
         # Define base tasks

--- a/server_management/management/commands/deploy.py
+++ b/server_management/management/commands/deploy.py
@@ -213,6 +213,7 @@ class Command(ServerManagementBaseCommand):
 
         python_version = remote['server'].get('python_version', '3')
         pip_command = 'pip{}'.format(python_version if python_version == '3' else '')
+        python_command = 'python{}'.format(python_version if python_version == '3' else '')
         # Define base tasks
         base_tasks = [
             # Add nginx and Let's Encrypt PPAs.  We add them up here because an
@@ -248,10 +249,10 @@ class Command(ServerManagementBaseCommand):
                         'ufw',  # Installed by default on Ubuntu, not elsewhere
 
                         # Project requirements
-                        'python{}-dev'.format(python_version if python_version == '3' else ''),
-                        'python{}-pip'.format(python_version if python_version == '3' else ''),
+                        '{}-dev'.format(python_command),
+                        '{}-pip'.format(python_command),
                         'apache2-utils',  # Required for htpasswd
-                        'python{}-passlib'.format(python_version if python_version == '3' else ''),  # Required for generating the htpasswd file
+                        '{}-passlib'.format(python_command),  # Required for generating the htpasswd file
                         'supervisor',
                         'libjpeg-dev',
                         'libffi-dev',
@@ -268,7 +269,10 @@ class Command(ServerManagementBaseCommand):
                         # Postgres requirements
                         'postgresql',
                         'libpq-dev',
-                        'python{}-psycopg2'.format(python_version if python_version == '3' else ''),  # TODO: Is this required?
+                        '{}-psycopg2'.format(python_command),  # TODO: Is this required?
+
+                        # Required under Python 3.
+                        'python3-venv' if python_version == '3' else '',
 
                         # Other
                         'libgeoip-dev' if optional_packages.get('geoip', True) else '',
@@ -593,7 +597,7 @@ class Command(ServerManagementBaseCommand):
         ]
         run_tasks(env, static_tasks)
 
-        virtualenv_command = 'virtualenv /var/www/{project}/.venv --no-site-packages' if python_version != '3' else 'python3 -m venv /var/www/{project}/.venv --no-site-packages'
+        virtualenv_command = 'virtualenv /var/www/{project}/.venv' if python_version != '3' else 'python3 -m venv /var/www/{project}/.venv'
         # Define venv tasks
         venv_tasks = [
             {

--- a/server_management/management/commands/deploy.py
+++ b/server_management/management/commands/deploy.py
@@ -15,7 +15,7 @@ from ._core import load_config, run_tasks, ServerManagementBaseCommand, title_pr
 
 
 class Command(ServerManagementBaseCommand):
-    def handle(self, noinput, debug, *args, remote='', **options):
+    def handle(self, noinput, debug, remote='', *args, **options):
         # Load server config from project
         config, remote = load_config(env, remote, config_user='root', debug=debug)
 

--- a/server_management/management/commands/deploy.py
+++ b/server_management/management/commands/deploy.py
@@ -604,6 +604,15 @@ class Command(ServerManagementBaseCommand):
                 'title': 'Create the virtualenv',
                 'command': virtualenv_command.format(project=project_folder)
             },
+            # This shouldn't be necessary (we think we upgraded pip earlier)
+            # but it is - you'll get complaints about bdist_wheel without
+            # this.
+            {
+                'title': 'Upgrade pip inside the virtualenv',
+                'command': '/var/www/{project}/.venv/bin/pip install --upgrade pip'.format(
+                    project=project_folder,
+                ),
+            },
         ]
         run_tasks(env, venv_tasks, user=project_folder)
 

--- a/server_management/management/commands/deploy.py
+++ b/server_management/management/commands/deploy.py
@@ -15,7 +15,7 @@ from ._core import load_config, run_tasks, ServerManagementBaseCommand, title_pr
 
 
 class Command(ServerManagementBaseCommand):
-    def handle(self, debug, noinput, debug, *args, remote='', **options):
+    def handle(self, noinput, debug, *args, remote='', **options):
         # Load server config from project
         config, remote = load_config(env, remote, config_user='root', debug=debug)
 

--- a/server_management/management/commands/deploy.py
+++ b/server_management/management/commands/deploy.py
@@ -141,6 +141,7 @@ class Command(ServerManagementBaseCommand):
             'memcached_supervisor_config': NamedTemporaryFile(delete=False),
             'nginx_site_config': NamedTemporaryFile(delete=False),
             'apt_periodic': NamedTemporaryFile(delete=False),
+            'certbot_cronjob': NamedTemporaryFile(delete=False),
         }
 
         # Parse files
@@ -169,6 +170,9 @@ class Command(ServerManagementBaseCommand):
 
         session_files['apt_periodic'].write(render_to_string('apt_periodic'))
         session_files['apt_periodic'].close()
+
+        session_files['certbot_cronjob'].write(render_to_string('certbot_cronjob'))
+        session_files['certbot_cronjob'].close()
 
         # Define the locales first.
         locale_tasks = [
@@ -675,6 +679,15 @@ class Command(ServerManagementBaseCommand):
             {
                 'title': "Ensure Nginx service is started",
                 'command': 'service nginx start',
+            },
+            {
+                'title': 'Configure certbot cronjob',
+                'fabric_command': 'put',
+                'fabric_args': [session_files['certbot_cronjob'].name, '/etc/cron.d/certbot'],
+            },
+            {
+                'title': "Ensure the certbot cronjob has the correct file permissions",
+                'command': 'chmod 0644 /etc/cron.d/certbot',
             },
         ]
         run_tasks(env, nginx_tasks)

--- a/server_management/management/commands/deploy.py
+++ b/server_management/management/commands/deploy.py
@@ -312,7 +312,7 @@ class Command(ServerManagementBaseCommand):
             },
             {
                 'title': "Add authorized keys to deploy user",
-                'command': 'mv /root/.ssh/authorized_keys /home/deploy/.ssh/authorized_keys ',
+                'command': 'mv /root/.ssh/authorized_keys /home/deploy/.ssh/authorized_keys',  # TODO: Integrate the initial_user fix.
             },
             {
                 'title': 'Check deploy user file permissions',

--- a/server_management/management/commands/deploy.py
+++ b/server_management/management/commands/deploy.py
@@ -212,7 +212,7 @@ class Command(ServerManagementBaseCommand):
             optional_packages = config['optional_packages']
 
         python_version = remote['server'].get('python_version', '3')
-
+        pip_command = 'pip{}'.format(python_version if python_version == '3' else '')
         # Define base tasks
         base_tasks = [
             # Add nginx and Let's Encrypt PPAs.  We add them up here because an
@@ -283,11 +283,11 @@ class Command(ServerManagementBaseCommand):
             },
             {
                 'title': 'Update pip',
-                'command': 'pip install -U pip',
+                'command': '{} install -U pip'.format(pip_command),
             },
             {
                 'title': 'Install virtualenv',
-                'command': 'pip install virtualenv',  # TODO: Will this need to change if we use Python 3? (probably)
+                'command': '{} install virtualenv'.format(pip_command),
             },
             {
                 'title': 'Set the timezone to UTC',

--- a/server_management/management/commands/deploy.py
+++ b/server_management/management/commands/deploy.py
@@ -580,9 +580,9 @@ class Command(ServerManagementBaseCommand):
         venv_tasks = [
             {
                 'title': "Create the virtualenv",
-                'command': 'virtualenv /var/www/{project}/.venv --no-site-packages creates=/var/www/{project}/.venv'.format(,
-                    )
-                }
+                'command': 'virtualenv /var/www/{project}/.venv --no-site-packages'.format(
+                    project=project_folder,
+                ),
             },
             {
                 'title': "Create the Gunicorn script file",
@@ -605,7 +605,7 @@ class Command(ServerManagementBaseCommand):
             },
             {
                 'title': "Create the application log file",
-                'command': 'touch /var/log/gunicorn_supervisor.log creates=/var/log/gunicorn_supervisor.log',
+                'command': 'touch /var/log/gunicorn_supervisor.log',
             },
             {
                 'title': "Set permission to the application log file",
@@ -727,20 +727,20 @@ class Command(ServerManagementBaseCommand):
             },
             {
                 'title': "Ensure that the default site is disabled",
-                'command': 'rm /etc/nginx/sites-enabled/default removes=/etc/nginx/sites-enabled/default',
+                'command': 'rm /etc/nginx/sites-enabled/default',
             },
             {
                 'title': "Ensure that the application site is enabled",
-                'command': 'ln -s /etc/nginx/sites-available/{project} /etc/nginx/sites-enabled/{project} creates=/etc/nginx/sites-enabled/{project}'.format(,
-                    )
-                }
+                'command': 'ln -s /etc/nginx/sites-available/{project} /etc/nginx/sites-enabled/{project}'.format(
+                    project=project_folder,
+                ),
             },
             {
                 'title': 'Run certbot',
-                'command': 'certbot certonly --standalone -n --agree-tos --email developers@onespacemedia.com --cert-name {} --domains {}'.format(,
-                        ','.join(setup_ssl_for)
-                    )
-                }
+                'command': 'certbot certonly --standalone -n --agree-tos --email developers@onespacemedia.com --cert-name {} --domains {}'.format(
+                    fallback_domain_name,
+                    ','.join(setup_ssl_for)
+                ),
             },
             {
                 'title': 'Generate DH parameters (this may take a little while)',

--- a/server_management/management/commands/deploy.py
+++ b/server_management/management/commands/deploy.py
@@ -205,6 +205,7 @@ class Command(ServerManagementBaseCommand):
                         # Base requirements
                         'build-essential',
                         'git',
+                        'ufw',  # Installed by default on Ubuntu, not elsewhere
 
                         # Project requirements
                         'python-dev',

--- a/server_management/management/commands/pulldb.py
+++ b/server_management/management/commands/pulldb.py
@@ -1,6 +1,6 @@
-from _core import load_config, ServerManagementBaseCommand
+from fabric.api import env, local, settings, sudo
 
-from fabric.api import *
+from ._core import load_config, ServerManagementBaseCommand
 
 
 class Command(ServerManagementBaseCommand):

--- a/server_management/management/commands/pullmedia.py
+++ b/server_management/management/commands/pullmedia.py
@@ -1,15 +1,15 @@
-from django.conf import settings as django_settings
-from fabric.api import *
-
-from _core import load_config, ServerManagementBaseCommand
 import os
+from django.conf import settings as django_settings
+from fabric.api import env, hide, lcd, local, settings
+
+from ._core import load_config, ServerManagementBaseCommand
 
 
 class Command(ServerManagementBaseCommand):
 
     def handle(self, *args, **options):
         # Load server config from project
-        config, remote = load_config(env, options.get('remote', ''))
+        load_config(env, options.get('remote', ''))
 
         # Set local project path
         local_project_path = django_settings.SITE_ROOT

--- a/server_management/management/commands/pushdb.py
+++ b/server_management/management/commands/pushdb.py
@@ -1,8 +1,7 @@
-from _core import load_config, ServerManagementBaseCommand, run_tasks
-
-from fabric.api import *
-
 import os
+from fabric.api import env, local, run, settings, sudo
+
+from ._core import load_config, ServerManagementBaseCommand, run_tasks
 
 
 class Command(ServerManagementBaseCommand):

--- a/server_management/management/commands/pushdb.py
+++ b/server_management/management/commands/pushdb.py
@@ -29,10 +29,7 @@ class Command(ServerManagementBaseCommand):
 
             # Define db tasks
             db_tasks = [
-                {
-                    'title': "Stop Supervisor tasks",
-                    'command': 'sudo supervisorctl stop all',
-                },
+                dict(title='Stop Supervisor tasks', command='sudo supervisorctl stop all'),
                 {
                     'title': 'Drop database',
                     'command': 'sudo su - postgres -c "dropdb -w {name}"'.format(
@@ -40,28 +37,28 @@ class Command(ServerManagementBaseCommand):
                     ),
                 },
                 {
-                    'title': "Ensure database is created",
+                    'title': 'Ensure database is created',
                     'command': 'sudo su - postgres -c "createdb {name} --encoding=UTF-8 --locale=en_GB.UTF-8 --template=template0 --owner={owner} --no-password"'.format(
                         name=remote['database']['name'],
                         owner=remote['database']['user'],
                     ),
                 },
                 {
-                    'title': "Ensure user has access to the database",
+                    'title': 'Ensure user has access to the database',
                     'command': 'sudo su - postgres -c "psql {name} -c \'GRANT ALL ON DATABASE {name} TO {owner}\'"'.format(
                         name=remote['database']['name'],
                         owner=remote['database']['user'],
                     ),
                 },
                 {
-                    'title': "Ensure user does not have unnecessary privileges",
+                    'title': 'Ensure user does not have unnecessary privileges',
                     'command': 'sudo su - postgres -c "psql {name} -c \'ALTER USER {owner} WITH NOSUPERUSER NOCREATEDB\'"'.format(
                         name=remote['database']['name'],
                         owner=remote['database']['user'],
                     ),
                 },
                 {
-                    'title': "Start Supervisor tasks",
+                    'title': 'Start Supervisor tasks',
                     'command': 'sudo supervisorctl start all',
                 },
             ]

--- a/server_management/management/commands/pushdb.py
+++ b/server_management/management/commands/pushdb.py
@@ -9,7 +9,7 @@ class Command(ServerManagementBaseCommand):
 
     def handle(self, *args, **options):
         # Load server config from project
-        config, remote = load_config(env, options.get('remote', ''))
+        config, remote = load_config(env, options.get('remote', ''), debug=options['debug'])
 
         with settings(warn_only=True):
 
@@ -32,62 +32,41 @@ class Command(ServerManagementBaseCommand):
             db_tasks = [
                 {
                     'title': "Stop Supervisor tasks",
-                    'ansible_arguments': {
-                        'module_name': 'command',
-                        'module_args': 'supervisorctl stop all'
-                    }
+                    'command': 'sudo supervisorctl stop all',
                 },
                 {
-                    'title': "Drop database",
-                    'ansible_arguments': {
-                        'module_name': 'postgresql_db',
-                        'module_args': "name='{}' state=absent".format(
-                                       remote['database']['name']
-                        ),
-                        'sudo_user': 'postgres'
-                    }
+                    'title': 'Drop database',
+                    'command': 'sudo su - postgres -c "dropdb -w {name}"'.format(
+                        name=remote['database']['name'],
+                    ),
                 },
                 {
                     'title': "Ensure database is created",
-                    'ansible_arguments': {
-                        'module_name': 'postgresql_db',
-                        'module_args': "name='{}' encoding='UTF-8' lc_collate='en_GB.UTF-8' lc_ctype='en_GB.UTF-8' "
-                                       "template='template0' state=present".format(
-                                           remote['database']['name']
-                                       ),
-                        'sudo_user': 'postgres'
-                    }
+                    'command': 'sudo su - postgres -c "createdb {name} --encoding=UTF-8 --locale=en_GB.UTF-8 --template=template0 --owner={owner} --no-password"'.format(
+                        name=remote['database']['name'],
+                        owner=remote['database']['user'],
+                    ),
                 },
                 {
                     'title': "Ensure user has access to the database",
-                    'ansible_arguments': {
-                        'module_name': 'postgresql_user',
-                        'module_args': "db='{}' name='{}' password='{}' priv=ALL state=present".format(
-                            remote['database']['name'],
-                            remote['database']['user'],
-                            remote['database']['password']
-                        ),
-                        'sudo_user': 'postgres'
-                    }
+                    'command': 'sudo su - postgres -c "psql {name} -c \'GRANT ALL ON DATABASE {name} TO {owner}\'"'.format(
+                        name=remote['database']['name'],
+                        owner=remote['database']['user'],
+                    ),
                 },
                 {
                     'title': "Ensure user does not have unnecessary privileges",
-                    'ansible_arguments': {
-                        'module_name': 'postgresql_user',
-                        'module_args': 'name={} role_attr_flags=NOSUPERUSER,NOCREATEDB state=present'.format(
-                            remote['database']['name']
-                        ),
-                        'sudo_user': 'postgres'
-                    }
+                    'command': 'sudo su - postgres -c "psql {name} -c \'ALTER USER {owner} WITH NOSUPERUSER NOCREATEDB\'"'.format(
+                        name=remote['database']['name'],
+                        owner=remote['database']['user'],
+                    ),
                 },
                 {
                     'title': "Start Supervisor tasks",
-                    'ansible_arguments': {
-                        'module_name': 'command',
-                        'module_args': 'supervisorctl start all'
-                    }
-                }
+                    'command': 'sudo supervisorctl start all',
+                },
             ]
+
             run_tasks(env, db_tasks)
 
             # Import the database file

--- a/server_management/management/commands/pushmedia.py
+++ b/server_management/management/commands/pushmedia.py
@@ -28,7 +28,7 @@ class Command(ServerManagementBaseCommand):
                     ), capture=True)
 
         with settings(warn_only=True):
-            local('rsync --progress -av{} {}/ {}@{}:/var/www/{}_media/'.format(
+            local('rsync --progress -O -av{} {}/ {}@{}:/var/www/{}_media/'.format(
                 ' ' if not getattr(env, 'key_filename') else ' -e "ssh -i {}"'.format(
                     os.path.expanduser(env.key_filename),  # Fixes an rsync bug with ~ paths.
                 ),

--- a/server_management/management/commands/pushmedia.py
+++ b/server_management/management/commands/pushmedia.py
@@ -1,10 +1,8 @@
-from django.conf import settings as django_settings
-from django.core.management.base import BaseCommand
-
-from _core import load_config, ServerManagementBaseCommand
-
-from fabric.api import *
 import os
+from django.conf import settings as django_settings
+from fabric.api import env, hide, lcd, local, settings
+
+from ._core import load_config, ServerManagementBaseCommand
 
 
 class Command(ServerManagementBaseCommand):
@@ -14,7 +12,7 @@ class Command(ServerManagementBaseCommand):
 
     def handle(self, *args, **options):
         # Load server config from project
-        config, remote = load_config(env, options.get('remote', ''))
+        load_config(env, options.get('remote', ''))
 
         # Set local project path
         local_project_path = django_settings.SITE_ROOT

--- a/server_management/management/commands/ssl.py
+++ b/server_management/management/commands/ssl.py
@@ -1,0 +1,75 @@
+import os
+
+from django.conf import settings as django_settings
+from fabric.api import abort, env, local, prompt
+from fabric.contrib.console import confirm
+
+from ._core import load_config, run_tasks, ServerManagementBaseCommand
+
+
+class Command(ServerManagementBaseCommand):
+
+    def handle(self, *args, **options):
+        # Load server config from project
+        _, remote = load_config(env, options.get('remote', ''), config_user='root', debug=options['debug'])
+
+        if django_settings.DEBUG:
+            abort(
+                "You're currently using your local settings file, you need use production instead.\n"
+                "To use production settings pass `--settings={}` to the deploy command.".format(
+                    os.getenv('DJANGO_SETTINGS_MODULE').replace('.local', '.production')
+                )
+            )
+
+        # Compress the domain names for nginx
+        domain_names = " ".join(django_settings.ALLOWED_HOSTS)
+
+        # Use the site domain as a fallback domain
+        fallback_domain_name = django_settings.SITE_DOMAIN
+
+        if not options['noinput']:
+            fallback_domain_name = prompt("What should the default domain be?", default=fallback_domain_name)
+            domain_names = prompt('Which domains would you like to enable in nginx?', default=domain_names)
+        else:
+            print 'Default domain: ', fallback_domain_name
+            print 'Domains to be enabled in nginx: ', domain_names
+
+        # If the domain is pointing to the droplet already, we can setup SSL.
+        setup_ssl_for = [
+            domain_name
+            for domain_name in domain_names.split(' ')
+            if local('dig +short {}'.format(domain_name), capture=True) == remote['server']['ip']
+        ]
+
+        if not setup_ssl_for:
+            abort("Sorry, it's $CURRENT_YEAR, you need to use SSL. Please update the domain DNS to point to {}.".format(
+                remote['server']['ip']
+            ))
+
+        for domain_name in domain_names.split(' '):
+            if domain_name not in setup_ssl_for:
+                print 'SSL will not be configured for {}'.format(domain_name)
+
+        if not options['noinput']:
+            if not confirm('Do you want to continue?'):
+                exit()
+
+        # Define nginx tasks
+        nginx_tasks = [
+            {
+                'title': "Ensure Nginx service is stopped",  # This allows Certbot to run.
+                'command': 'service nginx stop',
+            },
+            {
+                'title': 'Run certbot',
+                'command': 'certbot certonly --standalone -n --agree-tos --email developers@onespacemedia.com --cert-name {} --domains {}'.format(
+                    fallback_domain_name,
+                    ','.join(setup_ssl_for)
+                ),
+            },
+            {
+                'title': "Ensure Nginx service is started",
+                'command': 'service nginx start',
+            },
+        ]
+        run_tasks(env, nginx_tasks)

--- a/server_management/management/commands/ssl.py
+++ b/server_management/management/commands/ssl.py
@@ -28,7 +28,7 @@ class Command(ServerManagementBaseCommand):
         fallback_domain_name = django_settings.SITE_DOMAIN
 
         if not options['noinput']:
-            fallback_domain_name = prompt("What should the default domain be?", default=fallback_domain_name)
+            fallback_domain_name = prompt('What should the default domain be?', default=fallback_domain_name)
             domain_names = prompt('Which domains would you like to enable in nginx?', default=domain_names)
         else:
             print 'Default domain: ', fallback_domain_name
@@ -57,7 +57,7 @@ class Command(ServerManagementBaseCommand):
         # Define nginx tasks
         nginx_tasks = [
             {
-                'title': "Ensure Nginx service is stopped",  # This allows Certbot to run.
+                'title': 'Ensure Nginx service is stopped',  # This allows Certbot to run.
                 'command': 'service nginx stop',
             },
             {
@@ -68,7 +68,7 @@ class Command(ServerManagementBaseCommand):
                 ),
             },
             {
-                'title': "Ensure Nginx service is started",
+                'title': 'Ensure Nginx service is started',
                 'command': 'service nginx start',
             },
         ]

--- a/server_management/management/commands/update.py
+++ b/server_management/management/commands/update.py
@@ -15,18 +15,18 @@ class Command(ServerManagementBaseCommand):
     slack_enabled = False
     slack_endpoints = []
 
-    current_commit = os.popen("git rev-parse --short HEAD").read().strip()
-    remote = os.popen("git config --get remote.origin.url").read().split(':')[1].split('.')[0]
+    current_commit = os.popen('git rev-parse --short HEAD').read().strip()
+    remote = os.popen('git config --get remote.origin.url').read().split(':')[1].split('.')[0]
     remote = 'production'
 
     def _bitbucket_commit_url(self, commit):
-        return "<https://bitbucket.org/{}/commits/{commit}|{commit}>".format(
+        return '<https://bitbucket.org/{}/commits/{commit}|{commit}>'.format(
             self.remote,
             commit=commit,
         )
 
     def _bitbucket_diff_url(self, commit1, commit2):
-        return "<https://bitbucket.org/{}/branches/compare/{}..{}#diff|diff>".format(
+        return '<https://bitbucket.org/{}/branches/compare/{}..{}#diff|diff>'.format(
             self.remote,
             commit2,
             commit1,
@@ -201,15 +201,15 @@ class Command(ServerManagementBaseCommand):
                 ), capture=True)
 
         with settings(sudo_user=project_folder), cd('/var/www/{}'.format(project_folder)):
-            self.server_commit = run("git rev-parse --short HEAD")
-            settings_module = "{}.settings.{}".format(
+            self.server_commit = run('git rev-parse --short HEAD')
+            settings_module = '{}.settings.{}'.format(
                 project_folder,
                 remote['server'].get('settings_file', 'production'),
             )
 
             # Check which venv we need to use.
             with settings(warn_only=True):
-                result = run("bash -c '[ -d venv ]'")
+                result = run('bash -c \'[ -d venv ]\'')
 
             if result.return_code == 0:
                 venv = '/var/www/{}/venv/'.format(project_folder)
@@ -229,7 +229,7 @@ class Command(ServerManagementBaseCommand):
 
                 # Check if we have PyPy
                 with settings(warn_only=True):
-                    result = run("test -x /usr/bin/pypy")
+                    result = run('test -x /usr/bin/pypy')
 
                 if result.return_code == 0:
                     sudo('virtualenv -p /usr/bin/pypy {}'.format(venv))

--- a/server_management/management/commands/update.py
+++ b/server_management/management/commands/update.py
@@ -222,6 +222,7 @@ class Command(ServerManagementBaseCommand):
             git_changes = sudo('git pull --rebase')
 
             if 'is up to date.' in git_changes:
+                self.stdout.write('Server is up to date.')
                 exit()
 
             if 'requirements' in git_changes:

--- a/server_management/management/commands/update.py
+++ b/server_management/management/commands/update.py
@@ -218,7 +218,8 @@ class Command(ServerManagementBaseCommand):
 
             sudo('git config --global user.email "developers@onespacemedia.com"')
             sudo('git config --global user.name "Onespacemedia Developers"')
-            git_changes = sudo('git pull --autostash --rebase')
+            sudo('git config --global rebase.autoStash true')
+            git_changes = sudo('git pull --rebase')
 
             if 'is up to date.' in git_changes:
                 exit()

--- a/server_management/management/commands/update.py
+++ b/server_management/management/commands/update.py
@@ -1,14 +1,13 @@
-from django.conf import settings as django_settings
-from fabric.api import *
-from fabvenv import virtualenv
-
-from _core import load_config, ServerManagementBaseCommand
-
 import datetime
 import json
-import requests
 import os
 import sys
+import requests
+from django.conf import settings as django_settings
+from fabric.api import sudo, run, hide, lcd, settings, shell_env, cd, local, env
+from fabvenv import virtualenv
+
+from ._core import load_config, ServerManagementBaseCommand
 
 
 class Command(ServerManagementBaseCommand):

--- a/server_management/management/commands/update.py
+++ b/server_management/management/commands/update.py
@@ -279,7 +279,7 @@ class Command(ServerManagementBaseCommand):
                     if watson:
                         sudo('./manage.py buildwatson')
 
-                    sudo('supervisorctl restart all')
+        sudo('supervisorctl restart all')
 
         # Register the release with Opbeat.
         if 'opbeat' in config and config['opbeat']['app_id'] and config['opbeat']['secret_token']:

--- a/server_management/management/commands/update.py
+++ b/server_management/management/commands/update.py
@@ -176,6 +176,16 @@ class Command(ServerManagementBaseCommand):
         self._notify_failed(str(value))
         sys.__excepthook__(exctype, value, traceback)
 
+    def add_arguments(self, parser):
+        super(Command, self).add_arguments(parser)
+        parser.add_argument(
+            '--force-update',
+            action='store_true',
+            dest='force_update',
+            default=False,
+            help='Force server to update, even if there are no changes detected.',
+        )
+
     def handle(self, *args, **options):
         # Load server config from project
         config, remote = load_config(env, options.get('remote', ''))
@@ -221,11 +231,11 @@ class Command(ServerManagementBaseCommand):
             sudo('git config --global rebase.autoStash true')
             git_changes = sudo('git pull --rebase')
 
-            if 'is up to date.' in git_changes:
+            if 'is up to date.' in git_changes and not options['force_update']:
                 self.stdout.write('Server is up to date.')
                 exit()
 
-            if 'requirements' in git_changes:
+            if ('requirements' in git_changes) or options['force_update']:
                 # Rebuild the virtualenv.
                 sudo('rm -rf {}'.format(venv))
 

--- a/server_management/management/commands/update.py
+++ b/server_management/management/commands/update.py
@@ -196,13 +196,16 @@ class Command(ServerManagementBaseCommand):
         # Change into the local project folder
         with hide('output', 'running', 'warnings'):
             with lcd(local_project_path):
-
                 project_folder = local("basename $( find {} -name 'wsgi.py' -not -path '*/.venv/*' -not -path '*/venv/*' | xargs -0 -n1 dirname )".format(
                     local_project_path
                 ), capture=True)
 
-        with cd('/var/www/{}'.format(project_folder)):
+        with settings(sudo_user=project_folder), cd('/var/www/{}'.format(project_folder)):
             self.server_commit = run("git rev-parse --short HEAD")
+            settings_module = "{}.settings.{}".format(
+                project_folder,
+                remote['server'].get('settings_file', 'production'),
+            )
 
             # Check which venv we need to use.
             with settings(warn_only=True):
@@ -213,58 +216,41 @@ class Command(ServerManagementBaseCommand):
             else:
                 venv = '/var/www/{}/.venv/'.format(project_folder)
 
-            sudo('chown {}:webapps -R /var/www/*'.format(project_folder))
-            sudo('chmod -R g+w /var/www/{}*'.format(project_folder))
-            sudo('chmod ug+rwX -R /var/www/{}/.git'.format(project_folder))
+            sudo('git config --global user.email "developers@onespacemedia.com"')
+            sudo('git config --global user.name "Onespacemedia Developers"')
+            git_changes = sudo('git pull --autostash --rebase')
 
-            # Ensure the current user is in the webapps group.
-            sudo('usermod -aG webapps {}'.format(env.user))
-
-            run('git config --global user.email "developers@onespacemedia.com"')
-            run('git config --global user.name "Onespacemedia Developers"')
-            run('git stash')
-            git_changes = run('git pull')
-
-            sudo('chmod -R g+w /var/www/{}*'.format(project_folder))
+            if 'is up to date.' in git_changes:
+                exit()
 
             if 'requirements' in git_changes:
                 # Rebuild the virtualenv.
-                sudo('rm -rf {}'.format(venv), user=project_folder)
+                sudo('rm -rf {}'.format(venv))
 
                 # Check if we have PyPy
                 with settings(warn_only=True):
                     result = run("test -x /usr/bin/pypy")
 
                 if result.return_code == 0:
-                    sudo('virtualenv -p /usr/bin/pypy {}'.format(venv), user=project_folder)
+                    sudo('virtualenv -p /usr/bin/pypy {}'.format(venv))
                 else:
-                    sudo('virtualenv {}'.format(venv), user=project_folder)
-
-                sudo('chown -R {}:webapps {}'.format(project_folder, venv))
-                sudo('chmod -R g+w /var/www/{}*'.format(project_folder))
+                    sudo('virtualenv {}'.format(venv))
 
                 with virtualenv(venv):
-                    with shell_env(DJANGO_SETTINGS_MODULE="{}.settings.{}".format(
-                        project_folder,
-                        remote['server'].get('settings_file', 'production')
-                    )):
-
-                        sudo('[[ -e requirements.txt ]] && pip install -qr requirements.txt', user=project_folder)
+                    with shell_env(DJANGO_SETTINGS_MODULE=settings_module):
+                        sudo('[[ -e requirements.txt ]] && pip install -qr requirements.txt')
 
             with virtualenv(venv):
-                with shell_env(DJANGO_SETTINGS_MODULE="{}.settings.{}".format(
-                    project_folder,
-                    remote['server'].get('settings_file', 'production')
-                )):
-                    sudo('pip install -q gunicorn', user=project_folder)
+                with shell_env(DJANGO_SETTINGS_MODULE=settings_module):
+                    sudo('pip install -q gunicorn')
 
                     if remote['server'].get('build_system', 'npm') == 'npm':
-                        sudo('. ~/.nvm/nvm.sh && yarn', user=project_folder, shell='/bin/bash')
-                        sudo('. ~/.nvm/nvm.sh && yarn run build', user=project_folder, shell='/bin/bash')
+                        sudo('. ~/.nvm/nvm.sh && yarn', shell='/bin/bash')
+                        sudo('. ~/.nvm/nvm.sh && yarn run build', shell='/bin/bash')
 
-                    run('./manage.py collectstatic --noinput')
+                    sudo('./manage.py collectstatic --noinput')
 
-                    requirements = run('pip freeze')
+                    requirements = sudo('pip freeze')
                     compressor = False
                     watson = False
                     for line in requirements.split('\n'):
@@ -274,15 +260,14 @@ class Command(ServerManagementBaseCommand):
                             watson = True
 
                     if not compressor:
-                        sudo('./manage.py compileassets', user=project_folder)
+                        sudo('./manage.py compileassets')
 
-                    sudo('yes yes | ./manage.py migrate', user=project_folder)
+                    sudo('yes yes | ./manage.py migrate')
 
                     if watson:
-                        sudo('./manage.py buildwatson', user=project_folder)
+                        sudo('./manage.py buildwatson')
 
                     sudo('supervisorctl restart all')
-                    sudo('chown {}:webapps -R /var/www/*'.format(project_folder))
 
         # Register the release with Opbeat.
         if 'opbeat' in config and config['opbeat']['app_id'] and config['opbeat']['secret_token']:

--- a/server_management/management/commands/update.py
+++ b/server_management/management/commands/update.py
@@ -203,6 +203,10 @@ class Command(ServerManagementBaseCommand):
         # Set local project path
         local_project_path = django_settings.SITE_ROOT
 
+        # Get our python version - we'll need this while rebuilding the
+        # virtualenv.
+        python_version = remote['server'].get('python_version', '3')
+
         # Change into the local project folder
         with hide('output', 'running', 'warnings'):
             with lcd(local_project_path):
@@ -246,7 +250,7 @@ class Command(ServerManagementBaseCommand):
                 if result.return_code == 0:
                     sudo('virtualenv -p /usr/bin/pypy {}'.format(venv))
                 else:
-                    sudo('virtualenv {}'.format(venv))
+                    sudo('virtualenv -p python{} {}'.format(python_version, venv))
 
                 with virtualenv(venv):
                     with shell_env(DJANGO_SETTINGS_MODULE=settings_module):

--- a/server_management/templates/certbot_cronjob
+++ b/server_management/templates/certbot_cronjob
@@ -1,0 +1,1 @@
+56 3 * * * certbot renew --pre-hook "service nginx stop" --post-hook "service nginx start"

--- a/server_management/templates/nginx_site_config
+++ b/server_management/templates/nginx_site_config
@@ -34,7 +34,7 @@ server {
     listen [::]:443 ssl http2;
 
     # certs sent to the client in SERVER HELLO are concatenated in ssl_certificate
-    ssl_certificate /etc/letsencrypt/live/{{ fallback_domain_name }}/cert.pem;
+    ssl_certificate /etc/letsencrypt/live/{{ fallback_domain_name }}/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/{{ fallback_domain_name }}/privkey.pem;
     ssl_session_timeout 1d;
     ssl_session_cache shared:SSL:50m;
@@ -57,7 +57,7 @@ server {
     ssl_stapling_verify on;
 
     ## verify chain of trust of OCSP response using Root CA and Intermediate certs
-    ssl_trusted_certificate /etc/letsencrypt/live/{{ fallback_domain_name }}/fullchain.pem;
+    ssl_trusted_certificate /etc/letsencrypt/live/{{ fallback_domain_name }}/chain.pem;
 
     resolver 8.8.8.8;
 

--- a/server_management/templates/nginx_site_config
+++ b/server_management/templates/nginx_site_config
@@ -1,3 +1,6 @@
+# Base configuration from Mozilla SSL Configuration Generator
+# https://mozilla.github.io/server-side-tls/ssl-config-generator/?server=nginx-1.10.1&openssl=1.0.1e&hsts=yes&profile=intermediate
+
 upstream wsgi_server {
   # fail_timeout=0 means we always retry an upstream even if it failed
   # to return a good HTTP response (in case the Unicorn master nukes a
@@ -7,24 +10,68 @@ upstream wsgi_server {
 }
 
 server {
-    listen              80;
-    server_name         {{ domain_names }};
-    
+    listen 80 default_server;
+    listen [::]:80 default_server;
+
+    # Redirect all HTTP requests to HTTPS with a 301 Moved Permanently response.
+    return 301 https://$host$request_uri;
+}
+
+server {
+    # Password protection.  Placed at the top of the file to make it easier to remove.
     satisfy any;
     allow 80.6.99.23;
     deny all;
 
+    # Comment these two lines out to remove password protection.
+    # (Remember to run `sudo service nginx reload` after saving)
     auth_basic "Restricted";
     auth_basic_user_file /etc/nginx/htpasswd;
 
-    charset utf-8;
+    # SSL configuration
+    server_name {{ domain_names }};
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
 
-    # enable gzip compression
-    gzip on;
-    gzip_min_length  1100;
-    gzip_buffers  4 32k;
-    gzip_types    text/plain application/x-javascript text/xml text/css image/svg+xml;
-    gzip_vary on;
+    # certs sent to the client in SERVER HELLO are concatenated in ssl_certificate
+    ssl_certificate /etc/letsencrypt/live/{{ fallback_domain_name }}/cert.pem;
+    ssl_certificate_key /etc/letsencrypt/live/{{ fallback_domain_name }}/privkey.pem;
+    ssl_session_timeout 1d;
+    ssl_session_cache shared:SSL:50m;
+    ssl_session_tickets off;
+
+    # Diffie-Hellman parameter for DHE ciphersuites, recommended 2048 bits
+    ssl_dhparam /etc/ssl/dhparam.pem;
+
+    # intermediate configuration. tweak to your needs.
+    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+    ssl_ciphers 'ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:ECDHE-ECDSA-DES-CBC3-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA:!DSS';
+    ssl_prefer_server_ciphers on;
+
+    # HSTS (ngx_http_headers_module is required) (15768000 seconds = 6 months)
+    add_header Strict-Transport-Security max-age=15768000;
+
+    # OCSP Stapling ---
+    # fetch OCSP records from URL in ssl_certificate and cache them
+    ssl_stapling on;
+    ssl_stapling_verify on;
+
+    ## verify chain of trust of OCSP response using Root CA and Intermediate certs
+    ssl_trusted_certificate /etc/letsencrypt/live/{{ fallback_domain_name }}/fullchain.pem;
+
+    resolver 8.8.8.8;
+
+    # Project configuration
+    charset utf-8;
+    server_tokens off;
+
+    # Note: You should disable gzip for SSL traffic.
+    # See: https://bugs.debian.org/773332
+    # gzip on;
+    # gzip_min_length 1100;
+    # gzip_buffers 4 32k;
+    # gzip_types text/plain application/x-javascript text/xml text/css image/svg+xml;
+    # gzip_vary on;
 
     fastcgi_buffers 16 16k;
     fastcgi_buffer_size 32k;
@@ -34,9 +81,6 @@ server {
     proxy_busy_buffers_size 256k;
 
     client_max_body_size 4G;
-
-    access_log /var/log/nginx_access.log;
-    error_log /var/log/nginx_error.log;
 
     location /static/ {
         alias   /var/www/{{ project }}_static/;
@@ -66,11 +110,4 @@ server {
             break;
         }
     }
-}
-
-# Redirect all failed requests
-server {
-   listen 80 default_server;
-   server_name _;
-   rewrite  ^/(.*)$  http://{{ fallback_domain_name }}/$1 permanent;
 }

--- a/setup.py
+++ b/setup.py
@@ -21,5 +21,5 @@ setup(
     url='https://github.com/onespacemedia/server-management/',
     author='James Foley, Daniel Samuels',
     author_email='developers@onespacemedia.com',
-    install_requires=['django', 'fabric', 'requests', 'fabric-virtualenv'],
+    install_requires=['django', 'fabric3', 'requests', 'fabric-virtualenv'],
 )

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     description='A set of server management tools used by Onespacemedia.',
     long_description=README,
     url='https://github.com/onespacemedia/server-management/',
-    author='James Foley',
-    author_email='jamesfoley@onespacemedia.com',
-    install_requires=['django', 'fabric', 'ansible==1.8.4', 'requests', 'fabric-virtualenv'],
+    author='James Foley, Daniel Samuels',
+    author_email='developers@onespacemedia.com',
+    install_requires=['django', 'fabric', 'requests', 'fabric-virtualenv'],
 )

--- a/setup.py
+++ b/setup.py
@@ -21,5 +21,5 @@ setup(
     url='https://github.com/onespacemedia/server-management/',
     author='James Foley, Daniel Samuels',
     author_email='developers@onespacemedia.com',
-    install_requires=['django', 'fabric3', 'requests', 'fabric-virtualenv'],
+    install_requires=['django', 'fabric3', 'requests', 'fabric3-virtualenv'],
 )


### PR DESCRIPTION
* Resolves #38 
* Resolves #23 
* Resolves #43 
* Resolves #44 
* Resolves #4
* Resolves #46 

---

This is quite a large change.  I've stripped Ansible out to allow us to be freed from the shackles it's been placing on us. With this PR we gain the following:

* Ability to deploy to Ubuntu 16.04
* Ability to deploy to Debian Jessie (in theory, not tested)
* Default installation uses HTTP/2
* Default installation uses SSL via Let's Encrypt - scores A on SSLLabs (not currently sure what's preventing an A+)
* Uses Nginx and Let's Encrypt PPAs to allow for...
* Default installation uses the latest available version of Nginx
* Default installation uses the latest available version of Postgres
* Default installation uses the latest available version of OpenSSL
* Fixes an issue with NVM / Yarn etc not installing properly
* Gives us the ability to use Python 3 in our projects

Other changes which aren't necessarily additions:

* Deployment keys are generated for the project user, rather than the deploy user. This removes the requirement for `chmod` and `chown` everywhere.  All project files are downloaded, installed etc through the project user.  The deploy user is now only used for logging in.
* Slightly improved progress output, success / failure states are inline
* Adds the ability to deploy without any user input (pass `--noinput`)
* Provides a debug flag to improve debugging of problems (pass `--debug`)
* Requires production settings to be used which avoids issues with domain specifications
* Requires SSL to be installed
* Removes the support for very old server.json files which only allowed for a single host
* Swappiness and cache pressure values have been tweaked to be more suited for servers
* Ensures the static folder exists within the project before running `collectstatic`

I would like to investigate having per-OS commands, but this might be best as a separate PR

TODO:

* [x] I need to finish off removing Ansible completely, there might still be some remnants in other management files, I need to check.
* [x] I would like to clean up some of the imports, mainly getting rid of `from fabric.api import *`
* [x] Update the README, it still refers to Ansible
* [x] Implement the initial user fix (from #45)
* [x] Add a command to add production domains to SSL certs
* [x] Update the `update` command to support the new user structure.