### PR TITLE
Change nginx max post size to 15MB

### DIFF
--- a/server_management/templates/nginx_production
+++ b/server_management/templates/nginx_production
@@ -17,7 +17,7 @@ server {
     proxy_buffers 4 256k;
     proxy_busy_buffers_size 256k;
 
-    client_max_body_size 4G;
+    client_max_body_size 15M;
 
     # Make TCP send multiple buffers as individual packets.
     tcp_nodelay on;

--- a/server_management/templates/nginx_staging
+++ b/server_management/templates/nginx_staging
@@ -65,7 +65,7 @@ server {
     proxy_buffers 4 256k;
     proxy_busy_buffers_size 256k;
 
-    client_max_body_size 4G;
+    client_max_body_size 15M;
 
     # Make TCP send multiple buffers as individual packets.
     tcp_nodelay on;


### PR DESCRIPTION
There's rarely going to be a need for this to be higher. We can evaluate those cases on a case-by-case basis.