### PR TITLE
Remove call to os.getlogin() as it's unreliable

### DIFF
--- a/server_management/management/commands/pushdb.py
+++ b/server_management/management/commands/pushdb.py
@@ -1,4 +1,5 @@
 import os
+import pwd
 
 from fabric.api import env, local, run, settings, sudo
 
@@ -16,7 +17,7 @@ class Command(ServerManagementBaseCommand):
             # Create a final dump of the database
             local('pg_dump {name} -cOx -U {user} -f ~/{name}.sql --clean'.format(
                 name=config['local']['database']['name'],
-                user=os.getlogin()
+                user=pwd.getpwuid(os.geteuid())[0],
             ))
 
             # Push the database from earlier up to the server


### PR DESCRIPTION
Turns out `os.getlogin()` is not the most reliable thing:

```
$ python
Python 2.7.12 (default, Dec  4 2017, 14:50:18)
[GCC 5.4.0 20160609] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import os
>>> os.getlogin()
Traceback (most recent call last):
 File "<stdin>", line 1, in <module>
OSError: [Errno 2] No such file or directory
```