### PR TITLE
Move wsgi_server out of staging into the production config.

### DIFF
--- a/server_management/templates/nginx_production
+++ b/server_management/templates/nginx_production
@@ -1,6 +1,14 @@
 # Base configuration from Mozilla SSL Configuration Generator
 # https://mozilla.github.io/server-side-tls/ssl-config-generator/?server=nginx-1.10.1&openssl=1.0.1e&hsts=yes&profile=intermediate
 
+upstream wsgi_server {
+  # fail_timeout=0 means we always retry an upstream even if it failed
+  # to return a good HTTP response (in case the Unicorn master nukes a
+  # single worker for timing out).
+
+  server 127.0.0.1:2000 fail_timeout=0;
+}
+
 server {
     # SSL configuration
     server_name {{ domain_names }};

--- a/server_management/templates/nginx_staging
+++ b/server_management/templates/nginx_staging
@@ -1,14 +1,6 @@
 # Base configuration from Mozilla SSL Configuration Generator
 # https://mozilla.github.io/server-side-tls/ssl-config-generator/?server=nginx-1.10.1&openssl=1.0.1e&hsts=yes&profile=intermediate
 
-upstream wsgi_server {
-  # fail_timeout=0 means we always retry an upstream even if it failed
-  # to return a good HTTP response (in case the Unicorn master nukes a
-  # single worker for timing out).
-
-  server 127.0.0.1:2000 fail_timeout=0;
-}
-
 server {
     # Password protection.  Placed at the top of the file to make it easier to remove.
     # Comment out the following 5 lines of code to remove password protection.


### PR DESCRIPTION
This makes it easier to disable a staging site - we can just remove the symlink in `sites-enabled`. As of now this will cause an error starting nginx because the `wsgi_server` upstream is defined in the staging, not production, site configuration.