### PR TITLE
Add gzip to static files.

### DIFF
--- a/server_management/templates/nginx_production
+++ b/server_management/templates/nginx_production
@@ -30,8 +30,10 @@ server {
         expires 30d;
         add_header Pragma public;
         add_header Cache-Control "public";
-        gzip_static on;
+
+        gzip on;
         gzip_vary on;
+        gzip_types text/plain application/x-javascript application/javascript text/xml text/css image/svg+xml;
     }
 
     location /media/ {

--- a/server_management/templates/nginx_staging
+++ b/server_management/templates/nginx_staging
@@ -78,8 +78,10 @@ server {
         expires 30d;
         add_header Pragma public;
         add_header Cache-Control "public";
-        gzip_static on;
+
+        gzip on;
         gzip_vary on;
+        gzip_types text/plain application/x-javascript application/javascript text/xml text/css image/svg+xml;
     }
 
     location /media/ {


### PR DESCRIPTION
This should be safe over HTTPS, as the [BREACH](http://breachattack.com/) attack requires all three of these conditions to be true:

```
* Be served from a server that uses HTTP-level compression
* Reflect user-input in HTTP response bodies
* Reflect a secret (such as a CSRF token) in HTTP response bodies
```

...the last two of which are not true for static files. But I'd like someone to sanity-check that assumption for me.