### PR TITLE
[WIP] Update the commonly used functions to use Fabric instead of Fabric3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,6 @@ com_crashlytics_export_strings.xml
 crashlytics.properties
 crashlytics-build.properties
 .venv
+
+# VS Code
+.vscode/

--- a/server_management/management/commands/_core.py
+++ b/server_management/management/commands/_core.py
@@ -149,7 +149,7 @@ def prompt(text, default=None, validate=None):
         if not user_input and default is not None:
             return default
 
-        if (user_input and validate(user_input)) or (user_input and default is None):
+        if user_input and (validate is None or validate(user_input)):
             return user_input
 
 

--- a/server_management/management/commands/_core.py
+++ b/server_management/management/commands/_core.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 
 import json
+import os
 import sys
 
 from django.conf import settings
@@ -43,7 +44,7 @@ class ServerManagementBaseCommand(BaseCommand):  # pylint: disable=abstract-meth
 def load_config(remote=None, config_user='deploy', debug=False):
     # Load the json file
     try:
-        with open(f'{settings.SITE_ROOT}/server.json', 'r', encoding='utf-8') as json_data:
+        with open(os.path.join(settings.SITE_ROOT, 'server.json'), 'r', encoding='utf-8') as json_data:
             config = json.load(json_data)
     except Exception as e:
         print(e)

--- a/server_management/management/commands/backupdb.py
+++ b/server_management/management/commands/backupdb.py
@@ -1,49 +1,47 @@
 from django.utils.timezone import now
-from fabric.api import local, settings, sudo
 
 from ._core import ServerManagementBaseCommand, load_config
 
 
-def perform_backup(env, config, remote):
-    with settings(warn_only=True):
-        # Dump the database on the server.
-        sudo('su - {user} -c \'pg_dump {name} -cOx -U {user} -f /home/{user}/{name}.sql --clean\''.format(
-            name=remote['database']['name'],
-            user=remote['database']['user'],
-        ))
+def perform_backup(config, connection):
+    remote = config['remotes'][config['remote_name']]
 
-        backup_folder = '~/Backups/{}/{}'.format(
-            config['local']['database']['name'],
-            config['remote_name'],
-        )
+    # Dump the database on the server.
+    connection.sudo('su - {user} -c \'pg_dump {name} -cOx -U {user} -f /home/{user}/{name}.sql --clean\''.format(
+        name=remote['database']['name'],
+        user=remote['database']['user'],
+    ))
 
-        # Create a backups folder
-        local('mkdir -p {}'.format(backup_folder))
+    backup_folder = '~/Backups/{}/{}'.format(
+        config['local']['database']['name'],
+        config['remote_name'],
+    )
 
-        # Pull the SQL file down.
-        local('scp {} {}@{}:/home/{}/{}.sql {}/{}.sql'.format(
-            '' if not getattr(env, 'key_filename') else ' -i {} '.format(env.key_filename),
-            env.user,
-            env.host_string,
-            remote['database']['user'],
-            remote['database']['name'],
-            backup_folder,
-            now().strftime('%Y%m%d%H%M'),
-        ))
+    # Create a backups folder
+    connection.local('mkdir -p {}'.format(backup_folder))
 
-        # Delete the file on the server.
-        sudo('rm /home/{}/{}.sql'.format(
-            remote['database']['user'],
-            remote['database']['name'],
-        ))
+    # Pull the SQL file down.
+    connection.local('scp {} {}@{}:/home/{}/{}.sql {}/{}.sql'.format(
+        f' -i {connection.connect_kwargs["key_filename"]} ' if connection.connect_kwargs.get('key_filename', False) else '',
+        connection.user,
+        connection.host,
+        remote['database']['user'],
+        remote['database']['name'],
+        backup_folder,
+        now().strftime('%Y%m%d%H%M'),
+    ))
+
+    # Delete the file on the server.
+    connection.sudo('rm /home/{}/{}.sql'.format(
+        remote['database']['user'],
+        remote['database']['name'],
+    ))
 
 
 class Command(ServerManagementBaseCommand):
 
     def handle(self, *args, **options):
-        from fabric.api import env
-
         # Load server config from project
-        config, remote = load_config(env, options.get('remote', ''), debug=options.get('debug', False))
+        config, connection = load_config(options.get('remote', ''), debug=options.get('debug', False))
 
-        perform_backup(env, config, remote)
+        perform_backup(config, connection)

--- a/server_management/management/commands/backupdb.py
+++ b/server_management/management/commands/backupdb.py
@@ -22,7 +22,7 @@ def perform_backup(config, connection):
 
     # Pull the SQL file down.
     connection.local('scp {} {}@{}:/home/{}/{}.sql {}/{}.sql'.format(
-        f' -i {connection.connect_kwargs["key_filename"]} ' if connection.connect_kwargs.get('key_filename', False) else '',
+        f' -i {connection.connect_kwargs["key_filename"]} ' if connection.connect_kwargs.get('key_filename') else '',
         connection.user,
         connection.host,
         remote['database']['user'],

--- a/server_management/management/commands/backupdb.py
+++ b/server_management/management/commands/backupdb.py
@@ -1,3 +1,5 @@
+import os
+
 from django.utils.timezone import now
 
 from ._core import ServerManagementBaseCommand, load_config
@@ -7,9 +9,14 @@ def perform_backup(config, connection):
     remote = config['remotes'][config['remote_name']]
 
     # Dump the database on the server.
-    connection.sudo('su - {user} -c \'pg_dump {name} -cOx -U {user} -f /home/{user}/{name}.sql --clean\''.format(
+    connection.sudo('su - {user} -c \'pg_dump {name} -cOx -U {user} -f /{path} --clean\''.format(
         name=remote['database']['name'],
         user=remote['database']['user'],
+        path=os.path.join(
+            'home',
+            remote['database']['user'],
+            f'{remote["database"]["name"]}.sql'
+        )
     ))
 
     backup_folder = '~/Backups/{}/{}'.format(
@@ -21,20 +28,28 @@ def perform_backup(config, connection):
     connection.local('mkdir -p {}'.format(backup_folder))
 
     # Pull the SQL file down.
-    connection.local('scp {} {}@{}:/home/{}/{}.sql {}/{}.sql'.format(
-        f' -i {connection.connect_kwargs["key_filename"]} ' if connection.connect_kwargs.get('key_filename') else '',
+    connection.local('scp{}{}@{}:/{} {}'.format(
+        f' -i {connection.connect_kwargs["key_filename"]} ' if connection.connect_kwargs.get('key_filename') else ' ',
         connection.user,
         connection.host,
-        remote['database']['user'],
-        remote['database']['name'],
-        backup_folder,
-        now().strftime('%Y%m%d%H%M'),
+        os.path.join(
+            'home',
+            remote['database']['user'],
+            f'{remote["database"]["name"]}.sql'
+        ),
+        os.path.join(
+            backup_folder,
+            f'{now().strftime("%Y%m%d%H%M")}.sql'
+        )
     ))
 
     # Delete the file on the server.
-    connection.sudo('rm /home/{}/{}.sql'.format(
-        remote['database']['user'],
-        remote['database']['name'],
+    connection.sudo('rm /{}'.format(
+        os.path.join(
+            'home',
+            remote['database']['user'],
+            f'{remote["database"]["name"]}.sql'
+        )
     ))
 
 

--- a/server_management/management/commands/pullall.py
+++ b/server_management/management/commands/pullall.py
@@ -1,3 +1,7 @@
+import json
+import os
+
+from django.conf import settings
 from django.core.management import call_command
 
 from server_management.management.commands._core import ServerManagementBaseCommand, title_print, get_remote
@@ -6,7 +10,15 @@ from server_management.management.commands._core import ServerManagementBaseComm
 class Command(ServerManagementBaseCommand):
 
     def handle(self, *args, **options):
-        remote_prompt = get_remote(options.get('remote', ''))
+        # Load the json file
+        try:
+            with open(os.path.join(settings.SITE_ROOT, 'server.json'), 'r', encoding='utf-8') as json_data:
+                config = json.load(json_data)
+        except Exception as e:
+            print(e)
+            raise Exception('Something is wrong with the server.json file, make sure it exists and is valid JSON.')
+
+        remote_prompt = get_remote(options.get('remote', ''), config)
 
         title_print('Pulling database', 'task')
         call_command('pulldb', remote=remote_prompt)

--- a/server_management/management/commands/pulldb.py
+++ b/server_management/management/commands/pulldb.py
@@ -1,3 +1,5 @@
+import os
+
 from invoke import run as local
 from invoke import UnexpectedExit
 
@@ -12,25 +14,36 @@ class Command(ServerManagementBaseCommand):
 
 
         # Dump the database on the server.
-        connection.sudo("su - {user} -c 'pg_dump {name} -cOx -U {user} -f /home/{user}/{name}.sql --clean'".format(
+        connection.sudo("su - {user} -c 'pg_dump {name} -cOx -U {user} -f /{path} --clean'".format(
             name=remote['database']['name'],
             user=remote['database']['user'],
+            path=os.path.join(
+                'home',
+                remote['database']['user'],
+                f'{remote["database"]["name"]}.sql'
+            )
         ))
 
         # Pull the SQL file down.
-        connection.local('scp{} {}@{}:/home/{}/{}.sql ~/{}.sql'.format(
+        connection.local('scp{} {}@{}:/{} ~/{}.sql'.format(
             f' -i {connection.connect_kwargs["key_filename"]}' if connection.connect_kwargs.get('key_filename') else '',
             connection.user,
             connection.host,
-            remote['database']['user'],
-            remote['database']['name'],
+            os.path.join(
+                'home',
+                remote['database']['user'],
+                f'{remote["database"]["name"]}.sql'
+            ),
             config['local']['database']['name'],
         ))
 
         # Delete the file on the server.
-        connection.sudo('rm -f /home/{}/{}.sql'.format(
-            remote['database']['user'],
-            remote['database']['name'],
+        connection.sudo('rm -f /{}'.format(
+            os.path.join(
+                'home',
+                remote['database']['user'],
+                f'{remote["database"]["name"]}.sql'
+            )
         ))
 
         # Drop the local db

--- a/server_management/management/commands/pulldb.py
+++ b/server_management/management/commands/pulldb.py
@@ -40,7 +40,7 @@ class Command(ServerManagementBaseCommand):
                 config['local']['database']['name']
             ))
         except UnexpectedExit as e:
-            if not f'''database "{config['local']['database']['name']}" does not exist''' in e.result.stderr:
+            if not e.result.exited == 1:
                 raise e
 
         # Create a new db, this is an easy way to start fresh

--- a/server_management/management/commands/pulldb.py
+++ b/server_management/management/commands/pulldb.py
@@ -19,7 +19,7 @@ class Command(ServerManagementBaseCommand):
 
         # Pull the SQL file down.
         connection.local('scp{} {}@{}:/home/{}/{}.sql ~/{}.sql'.format(
-            f' -i {connection.connect_kwargs["key_filename"]}' if connection.connect_kwargs.get('key_filename', False) else '',
+            f' -i {connection.connect_kwargs["key_filename"]}' if connection.connect_kwargs.get('key_filename') else '',
             connection.user,
             connection.host,
             remote['database']['user'],

--- a/server_management/management/commands/pulldb.py
+++ b/server_management/management/commands/pulldb.py
@@ -1,53 +1,59 @@
-from fabric.api import env, local, settings, sudo
+from invoke import run as local
+from invoke import UnexpectedExit
 
 from ._core import ServerManagementBaseCommand, load_config
 
 
 class Command(ServerManagementBaseCommand):
-
     def handle(self, *args, **options):
         # Load server config from project
-        config, remote = load_config(env, options.get('remote', ''), debug=options.get('debug', False))
+        config, connection = load_config(options.get('remote', ''), debug=options.get('debug', False))
+        remote = config['remotes'][config['remote_name']]
 
-        with settings(warn_only=True):
-            # Dump the database on the server.
-            sudo("su - {user} -c 'pg_dump {name} -cOx -U {user} -f /home/{user}/{name}.sql --clean'".format(
-                name=remote['database']['name'],
-                user=remote['database']['user'],
-            ))
 
-            # Pull the SQL file down.
-            local('scp {} {}@{}:/home/{}/{}.sql ~/{}.sql'.format(
-                '' if not getattr(env, 'key_filename') else ' -i {} '.format(env.key_filename),
-                env.user,
-                env.host_string,
-                remote['database']['user'],
-                remote['database']['name'],
-                config['local']['database']['name'],
-            ))
+        # Dump the database on the server.
+        connection.sudo("su - {user} -c 'pg_dump {name} -cOx -U {user} -f /home/{user}/{name}.sql --clean'".format(
+            name=remote['database']['name'],
+            user=remote['database']['user'],
+        ))
 
-            # Delete the file on the server.
-            sudo('rm -f /home/{}/{}.sql'.format(
-                remote['database']['user'],
-                remote['database']['name'],
-            ))
+        # Pull the SQL file down.
+        connection.local('scp{} {}@{}:/home/{}/{}.sql ~/{}.sql'.format(
+            f' -i {connection.connect_kwargs["key_filename"]}' if connection.connect_kwargs.get('key_filename', False) else '',
+            connection.user,
+            connection.host,
+            remote['database']['user'],
+            remote['database']['name'],
+            config['local']['database']['name'],
+        ))
 
-            # Drop the local db
+        # Delete the file on the server.
+        connection.sudo('rm -f /home/{}/{}.sql'.format(
+            remote['database']['user'],
+            remote['database']['name'],
+        ))
+
+        # Drop the local db
+        try:
+            # We use invoke's run() here (which we've imported as local() for readability) to maintain the PATH envvar so we have access to PSQL commands
             local('dropdb {}'.format(
                 config['local']['database']['name']
             ))
+        except UnexpectedExit as e:
+            if not f'''database "{config['local']['database']['name']}" does not exist''' in e.result.stderr:
+                raise e
 
-            # Create a new db, this is an easy way to start fresh
-            local('createdb {}'.format(
-                config['local']['database']['name']
-            ))
+        # Create a new db, this is an easy way to start fresh
+        local('createdb {}'.format(
+            config['local']['database']['name']
+        ))
 
-            # Import the database locally
-            local('psql -q {name} < ~/{name}.sql > /dev/null 2>&1'.format(
-                name=config['local']['database']['name'],
-            ))
+        # Import the database locally
+        local('psql -q {name} < ~/{name}.sql > /dev/null 2>&1'.format(
+            name=config['local']['database']['name'],
+        ))
 
-            # Cleanup local files
-            local('rm ~/{}.sql'.format(
-                config['local']['database']['name'],
-            ))
+        # Cleanup local files
+        connection.local('rm ~/{}.sql'.format(
+            config['local']['database']['name'],
+        ))

--- a/server_management/management/commands/pullmedia.py
+++ b/server_management/management/commands/pullmedia.py
@@ -1,42 +1,29 @@
 import os
 
 from django.conf import settings as django_settings
-from fabric.api import env, hide, lcd, local, settings
 
 from ._core import ServerManagementBaseCommand, load_config
 
 
 class Command(ServerManagementBaseCommand):
-
     def handle(self, *args, **options):
         # Load server config from project
-        load_config(env, options.get('remote', ''), debug=options.get('debug', False))
+        _, connection = load_config(options.get('remote', ''), debug=options.get('debug', False))
 
-        # Set local project path
-        local_project_path = django_settings.SITE_ROOT
+        connection.local('mkdir -p {}/uploads/'.format(
+            django_settings.MEDIA_ROOT
+        ))
 
-        # Change into the local project folder
-        with hide('output', 'running', 'warnings'):
-            with lcd(local_project_path):
-                project_folder = local("basename $( find {} -name 'wsgi.py' -not -path '*/.venv/*' -not -path '*/venv/*' | xargs -0 -n1 dirname )".format(
-                    local_project_path
-                ), capture=True)
+        connection.local('mkdir -p {}'.format(
+            django_settings.STATIC_ROOT
+        ))
 
-        with settings(warn_only=True):
-            local('mkdir -p {}/uploads/'.format(
-                django_settings.MEDIA_ROOT
-            ))
-
-            local('mkdir -p {}'.format(
-                django_settings.STATIC_ROOT
-            ))
-
-            local('rsync --progress -av{} --exclude "assets/" --exclude "cache/" {}@{}:/var/www/{}_media/ {}'.format(
-                ' ' if not getattr(env, 'key_filename') else ' -e "ssh -i {}"'.format(
-                    os.path.expanduser(env.key_filename),  # Fixes an rsync bug with ~ paths.
-                ),
-                env.user,
-                env.host_string,
-                project_folder,
-                django_settings.MEDIA_ROOT
-            ))
+        connection.local('rsync --progress -av{} --exclude "assets/" --exclude "cache/" {}@{}:/var/www/{}_media/ {}'.format(
+            '' if not connection.connect_kwargs.get('key_filename', False) else ' -e "ssh -i {}"'.format(
+                os.path.expanduser(connection.connect_kwargs['key_filename']),  # Fixes an rsync bug with ~ paths.
+            ),
+            connection.user,
+            connection.host,
+            os.path.basename(django_settings.SITE_ROOT),
+            django_settings.MEDIA_ROOT
+        ))

--- a/server_management/management/commands/pullmedia.py
+++ b/server_management/management/commands/pullmedia.py
@@ -10,8 +10,8 @@ class Command(ServerManagementBaseCommand):
         # Load server config from project
         _, connection = load_config(options.get('remote', ''), debug=options.get('debug', False))
 
-        connection.local('mkdir -p {}/uploads/'.format(
-            django_settings.MEDIA_ROOT
+        connection.local('mkdir -p {}'.format(
+            os.path.join(django_settings.MEDIA_ROOT, 'uploads')
         ))
 
         connection.local('mkdir -p {}'.format(
@@ -19,7 +19,7 @@ class Command(ServerManagementBaseCommand):
         ))
 
         connection.local('rsync --progress -av{} --exclude "assets/" --exclude "cache/" {}@{}:/var/www/{}_media/ {}'.format(
-            '' if not connection.connect_kwargs.get('key_filename', False) else ' -e "ssh -i {}"'.format(
+            '' if not connection.connect_kwargs.get('key_filename') else ' -e "ssh -i {}"'.format(
                 os.path.expanduser(connection.connect_kwargs['key_filename']),  # Fixes an rsync bug with ~ paths.
             ),
             connection.user,

--- a/server_management/management/commands/pushdb.py
+++ b/server_management/management/commands/pushdb.py
@@ -1,9 +1,9 @@
 import os
 
 from django.conf import settings as django_settings
-from fabric.api import env, local, run, settings, sudo
+from invoke import run as local
 
-from ._core import ServerManagementBaseCommand, load_config, run_tasks
+from ._core import ServerManagementBaseCommand, load_config, run_tasks, title_print
 from .backupdb import perform_backup
 
 
@@ -14,81 +14,78 @@ class Command(ServerManagementBaseCommand):
             raise Exception('Database pushing has been disabled.')
 
         # Load server config from project
-        config, remote = load_config(env, options.get('remote', ''), debug=options.get('debug', False))
+        config, connection = load_config(options.get('remote', ''), debug=options.get('debug', False))
+        remote = config['remotes'][config['remote_name']]
 
-        print('Making a backup')
-        perform_backup(env, config, remote)
-        print('Backup made')
+        title_print('Backing up database', 'task')
+        perform_backup(config, connection)
+        title_print('Backing up database', 'succeeded')
 
-        with settings(warn_only=True):
+        # Create a final dump of the database. We use Invoke's run() here as Postgres' pg_dump won't work since postgres won't be in $PATH for connection.local()
+        local('pg_dump {name} -cOx -U {user} -f ~/{name}.sql --clean'.format(
+            name=config['local']['database']['name'],
+            user=os.getlogin()
+        ))
 
-            # Create a final dump of the database
-            local('pg_dump {name} -cOx -U {user} -f ~/{name}.sql --clean'.format(
-                name=config['local']['database']['name'],
-                user=os.getlogin()
-            ))
+        # Push the database from earlier up to the server
+        connection.local('scp{}~/{}.sql {}@{}:/tmp/{}.sql'.format(
+            f' -i {connection.connect_kwargs["key_filename"]} ' if connection.connect_kwargs.get('key_filename') else ' ',
+            config['local']['database']['name'],
+            connection.user,
+            remote['server']['ip'],
+            remote['database']['name'],
+        ))
 
-            # Push the database from earlier up to the server
-            local('scp{}~/{}.sql {}@{}:/tmp/{}.sql'.format(
-                ' ' if not getattr(env, 'key_filename') else ' -i {} '.format(env.key_filename),
-                config['local']['database']['name'],
-                env.user,
-                remote['server']['ip'],
-                remote['database']['name'],
-            ))
+        # Define db tasks
+        db_tasks = [
+            dict(title='Stop Supervisor tasks', command='sudo supervisorctl stop all'),
+            {
+                'title': 'Drop database',
+                'command': 'sudo su - postgres -c "dropdb -w {name}"'.format(
+                    name=remote['database']['name'],
+                ),
+            },
+            {
+                'title': 'Ensure database is created',
+                'command': 'sudo su - postgres -c "createdb {name} --encoding=UTF-8 --locale=en_GB.UTF-8 --template=template0 --owner={owner} --no-password"'.format(
+                    name=remote['database']['name'],
+                    owner=remote['database']['user'],
+                ),
+            },
+            {
+                'title': 'Ensure user has access to the database',
+                'command': 'sudo su - postgres -c "psql {name} -c \'GRANT ALL ON DATABASE {name} TO {owner}\'"'.format(
+                    name=remote['database']['name'],
+                    owner=remote['database']['user'],
+                ),
+            },
+            {
+                'title': 'Ensure user does not have unnecessary privileges',
+                'command': 'sudo su - postgres -c "psql {name} -c \'ALTER USER {owner} WITH NOSUPERUSER NOCREATEDB\'"'.format(
+                    name=remote['database']['name'],
+                    owner=remote['database']['user'],
+                ),
+            },
+            {
+                'title': 'Start Supervisor tasks',
+                'command': 'sudo supervisorctl start all',
+            },
+        ]
 
-            # Define db tasks
-            db_tasks = [
-                dict(title='Stop Supervisor tasks', command='sudo supervisorctl stop all'),
-                {
-                    'title': 'Drop database',
-                    'command': 'sudo su - postgres -c "dropdb -w {name}"'.format(
-                        name=remote['database']['name'],
-                    ),
-                },
-                {
-                    'title': 'Ensure database is created',
-                    'command': 'sudo su - postgres -c "createdb {name} --encoding=UTF-8 --locale=en_GB.UTF-8 --template=template0 --owner={owner} --no-password"'.format(
-                        name=remote['database']['name'],
-                        owner=remote['database']['user'],
-                    ),
-                },
-                {
-                    'title': 'Ensure user has access to the database',
-                    'command': 'sudo su - postgres -c "psql {name} -c \'GRANT ALL ON DATABASE {name} TO {owner}\'"'.format(
-                        name=remote['database']['name'],
-                        owner=remote['database']['user'],
-                    ),
-                },
-                {
-                    'title': 'Ensure user does not have unnecessary privileges',
-                    'command': 'sudo su - postgres -c "psql {name} -c \'ALTER USER {owner} WITH NOSUPERUSER NOCREATEDB\'"'.format(
-                        name=remote['database']['name'],
-                        owner=remote['database']['user'],
-                    ),
-                },
-                {
-                    'title': 'Start Supervisor tasks',
-                    'command': 'sudo supervisorctl start all',
-                },
-            ]
+        run_tasks(connection, db_tasks)
 
-            run_tasks(env, db_tasks)
+        # Import the database file
+        # sudo("su - {name} -c 'psql -q {name} < /tmp/{name}.sql > /dev/null 2>&1'".format(
+        connection.sudo('psql {name} < /tmp/{name}.sql'.format(
+            name=remote['database']['name']
+        ), user=remote['database']['user'])
 
-            # Import the database file
-            # sudo("su - {name} -c 'psql -q {name} < /tmp/{name}.sql > /dev/null 2>&1'".format(
+        # Remove the database file
+        connection.run('rm /tmp/{}.sql'.format(
+            remote['database']['name']
+        ))
 
-            with settings(sudo_user=remote['database']['user']):
-                sudo('psql {name} < /tmp/{name}.sql'.format(
-                    name=remote['database']['name']
-                ))
-
-            # Remove the database file
-            run('rm /tmp/{}.sql'.format(
-                remote['database']['name']
-            ))
-
-            # Remove the SQL file from the host
-            local('rm ~/{}.sql'.format(
-                config['local']['database']['name']
-            ))
+        # Remove the SQL file from the host
+        connection.local('rm ~/{}.sql'.format(
+            config['local']['database']['name']
+        ))

--- a/server_management/management/commands/pushdb.py
+++ b/server_management/management/commands/pushdb.py
@@ -28,12 +28,15 @@ class Command(ServerManagementBaseCommand):
         ))
 
         # Push the database from earlier up to the server
-        connection.local('scp{}~/{}.sql {}@{}:/tmp/{}.sql'.format(
+        connection.local('scp{}~/{}.sql {}@{}:/{}'.format(
             f' -i {connection.connect_kwargs["key_filename"]} ' if connection.connect_kwargs.get('key_filename') else ' ',
             config['local']['database']['name'],
             connection.user,
             remote['server']['ip'],
-            remote['database']['name'],
+            os.path.join(
+                'tmp',
+                f'{remote["database"]["name"]}.sql'
+            )
         ))
 
         # Define db tasks
@@ -76,8 +79,12 @@ class Command(ServerManagementBaseCommand):
 
         # Import the database file
         # sudo("su - {name} -c 'psql -q {name} < /tmp/{name}.sql > /dev/null 2>&1'".format(
-        connection.sudo('psql {name} < /tmp/{name}.sql'.format(
-            name=remote['database']['name']
+        connection.sudo('psql {} < /{}'.format(
+            remote['database']['name'],
+            os.path.join(
+                'tmp',
+                f'{remote["database"]["name"]}.sql'
+            )
         ), user=remote['database']['user'])
 
         # Remove the database file

--- a/server_management/management/commands/pushmedia.py
+++ b/server_management/management/commands/pushmedia.py
@@ -1,7 +1,6 @@
 import os
 
 from django.conf import settings as django_settings
-from fabric.api import env, hide, lcd, local, settings
 
 from ._core import ServerManagementBaseCommand, load_config
 
@@ -10,27 +9,15 @@ class Command(ServerManagementBaseCommand):
 
     def handle(self, *args, **options):
         # Load server config from project
-        load_config(env, options.get('remote', ''), debug=options.get('debug', False))
+        _, connection = load_config(options.get('remote', ''), debug=options.get('debug', False))
 
-        # Set local project path
-        local_project_path = django_settings.SITE_ROOT
-
-        # Change into the local project folder
-        with hide('output', 'running', 'warnings'):
-            with lcd(local_project_path):
-                project_folder = local(
-                    "basename $( find {} -name 'wsgi.py' -not -path '*/.venv/*' -not -path '*/venv/*' | xargs -0 -n1 dirname )".format(
-                        local_project_path
-                    ), capture=True)
-
-        with settings(warn_only=True):
-            local('rsync --rsync-path="sudo -u {} rsync" --progress --exclude "cache/" -O -av{} {}/ {}@{}:/var/www/{}_media/'.format(
-                project_folder,
-                ' ' if not getattr(env, 'key_filename') else ' -e "ssh -i {}"'.format(
-                    os.path.expanduser(env.key_filename),  # Fixes an rsync bug with ~ paths.
-                ),
-                django_settings.MEDIA_ROOT,
-                env.user,
-                env.host_string,
-                project_folder,
-            ))
+        connection.local('rsync --rsync-path="sudo -u {} rsync" --progress --exclude "cache/" -O -av{} {}/ {}@{}:/var/www/{}_media/'.format(
+            os.path.basename(django_settings.SITE_ROOT),
+            '' if not connection.connect_kwargs.get('key_filename') else ' -e "ssh -i {}"'.format(
+                os.path.expanduser(connection.connect_kwargs['key_filename']),  # Fixes an rsync bug with ~ paths.
+            ),
+            django_settings.MEDIA_ROOT,
+            connection.user,
+            connection.host,
+            os.path.basename(django_settings.SITE_ROOT),
+        ))


### PR DESCRIPTION
fabric3 is dead since as of version 2, fabric supports python 3. fabric3 uses pycrypto which is itself an old a dead package. I'd rather not use an out of date cryptography package if we can avoid it. 

This does mean we have to change how all the commands work however as the syntax for fabric 2.0 is wildly different to fabric 1.0 which is what the syntax for fabric3 was based on.

All commands updated, commands tested:
- [x] Backup DB
- [ ] Deploy
- [x] Pull all
- [x] Pull DB
- [x] Pull Media
- [ ] Push DB 
- [ ] Push media
- [ ] SSL
- [ ] Update